### PR TITLE
(WIP) expose metrics via prometheus client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 __pycache__
+.vscode/
 config.py

--- a/README.md
+++ b/README.md
@@ -20,3 +20,22 @@ SERVER = 'mongodb://mongodb.example.com:27017/'
 pip install pymongo
 python get-stats-for-yesterday.py
 ```
+
+## Development
+
+Below is an example of a single entry in the list of failure causes:
+
+```python
+Single dailyFailureCause
+
+{
+    '_id': ObjectId('sc = 546d33efe4b0220750244af7'),
+    'name': 'Apt failure - hash sum mismatch',
+    'description': 'When using the \'apt\' package manager, the job may fail with "hash sum mismatch". This can occur when using a caching proxy, or a mirror in an inconsistent state. The job should be retried, and the content mirrored locally.',
+    'comment': '',
+    'categories': ['apt', 'network', 'debian', 'ubuntu'],
+    'indications': [{'@class': 'com.sonyericsson.jenkins.plugins.bfa.model.indication.BuildLogIndication', 'pattern': '.*Hash Sum mismatch.*'}],
+    'modifications': [{'user': 'branan', 'time': datetime.datetime(2014, 11, 17, 22, 42, 4, 410000)}],
+    'lastOccurred': datetime.datetime(2019, 8, 6, 14, 1, 2, 955000)
+}
+```

--- a/get-stats.py
+++ b/get-stats.py
@@ -1,5 +1,7 @@
 from datetime import datetime, time, timedelta
 import pprint
+from prometheus_client import start_http_server
+from prometheus_client.core import CounterMetricFamily, REGISTRY
 from pymongo import MongoClient
 import config
 client = MongoClient(config.SERVER)
@@ -9,7 +11,7 @@ categorizedFailures = []
 uncategorizedFailures = []
 midnight = datetime.combine(datetime.today(), time.min)
 yesterday_midnight = midnight - timedelta(days=1)
-dailyFailureCauses = failureCausesCollection.find({'lastOccurred': {'$gte': yesterday_midnight, '$lt': midnight}})
+dailyFailureCauses = failureCausesCollection.find({'lastOccurred': {'$gte': midnight}})
 for dailyFailureCause in dailyFailureCauses:
     if 'categories' in dailyFailureCause.keys():
         categorizedFailures.append(dailyFailureCause)
@@ -25,9 +27,9 @@ for categorizedFailure in categorizedFailures:
 
 failureCounts = []
 for uniqueCategory in uniqueCategories:
-    failures = failureCausesCollection.find({'lastOccurred': {'$gte': yesterday_midnight, '$lt': midnight}, 'categories': {'$in': [uniqueCategory]}})
+    failures = failureCausesCollection.find({'lastOccurred': {'$gte': midnight}, 'categories': {'$in': [uniqueCategory]}})
     categoryInfo = {}
-    categoryInfo['category'] = uniqueCategory
+    categoryInfo['category'] = uniqueCategory.lower()
     categoryInfo['failures'] = failures.count()
     failureCounts.append(categoryInfo)
 
@@ -36,4 +38,23 @@ uncategorizedFailureInfo['category'] = u'uncategorized'
 uncategorizedFailureInfo['failures'] = len(uncategorizedFailures)
 failureCounts.append(uncategorizedFailureInfo)
 
-pprint.pprint(failureCounts)
+# pprint.pprint(failureCounts)
+
+class CustomCollector(object):
+    def collect(self):
+        c = CounterMetricFamily('jenkins_bfa_failures_total', 'Total failures since midnight', labels=['failure_category'])
+        for failureCount in failureCounts:
+            metric_name = failureCount['category']
+            metric_value = failureCount['failures']
+            c.add_metric([metric_name], metric_value)
+        c.add_metric(['all'], dailyFailureCauses.count())
+        yield c
+
+REGISTRY.register(CustomCollector())
+
+
+if __name__ == '__main__':
+    # Start up the server to expose the metrics.
+    start_http_server(8000)
+    while True:
+        CustomCollector.collect

--- a/get-stats.py
+++ b/get-stats.py
@@ -1,53 +1,75 @@
-from datetime import datetime, time, timedelta
+#!/usr/bin/env python3
+
+import datetime
 import pprint
+import time
 from prometheus_client import start_http_server
 from prometheus_client.core import CounterMetricFamily, REGISTRY
 from pymongo import MongoClient
 import config
+
 client = MongoClient(config.SERVER)
 db = client.jenkinsbfa
 failureCausesCollection = db.failureCauses
-categorizedFailures = []
-uncategorizedFailures = []
-midnight = datetime.combine(datetime.today(), time.min)
-yesterday_midnight = midnight - timedelta(days=1)
-dailyFailureCauses = failureCausesCollection.find({'lastOccurred': {'$gte': midnight}})
-for dailyFailureCause in dailyFailureCauses:
-    if 'categories' in dailyFailureCause.keys():
-        categorizedFailures.append(dailyFailureCause)
-    else:
-        uncategorizedFailures.append(dailyFailureCause)
 
-uniqueCategories = []
-for categorizedFailure in categorizedFailures:
-    categories = categorizedFailure['categories']
-    for category in categories:
-        if category not in uniqueCategories:
-            uniqueCategories.append(category)
+def get_daily_failures(self):
+    dailyFailures = {}
+    categorizedFailures = []
+    uncategorizedFailures = []
+    midnight = datetime.datetime.combine(datetime.datetime.today(), datetime.time.min)
+    yesterday_midnight = midnight - datetime.timedelta(days=1)
+    dailyFailureCauses = failureCausesCollection.find({'lastOccurred': {'$gte': midnight}})
+    daily_failure_causes_count = dailyFailureCauses.count()
+    for dailyFailureCause in dailyFailureCauses:
+        if 'categories' in dailyFailureCause.keys():
+            categorizedFailures.append(dailyFailureCause)
+        else:
+            uncategorizedFailures.append(dailyFailureCause)
 
-failureCounts = []
-for uniqueCategory in uniqueCategories:
-    failures = failureCausesCollection.find({'lastOccurred': {'$gte': midnight}, 'categories': {'$in': [uniqueCategory]}})
-    categoryInfo = {}
-    categoryInfo['category'] = uniqueCategory.lower()
-    categoryInfo['failures'] = failures.count()
-    failureCounts.append(categoryInfo)
+    uniqueCategories = []
+    for categorizedFailure in categorizedFailures:
+        categories = categorizedFailure['categories']
+        for category in categories:
+            if category not in uniqueCategories:
+                uniqueCategories.append(category)
+                
+    dailyFailures['categorizedFailures'] = categorizedFailures
+    dailyFailures['uncategorizedFailures'] = uncategorizedFailures
+    dailyFailures['midnight'] = midnight
+    dailyFailures['yesterday_midnight'] = yesterday_midnight
+    dailyFailures['daily_failure_causes_count'] = daily_failure_causes_count
+    dailyFailures['uniqueCategories'] = uniqueCategories
+    return dailyFailures
 
-uncategorizedFailureInfo = {}
-uncategorizedFailureInfo['category'] = u'uncategorized'
-uncategorizedFailureInfo['failures'] = len(uncategorizedFailures)
-failureCounts.append(uncategorizedFailureInfo)
+def get_failure_counts(self):
+    dailyFailures = get_daily_failures(self)
+    failureCounts = []
+    for uniqueCategory in dailyFailures['uniqueCategories']:
+        categoryInfo = {}
+        categoryInfo['category'] = uniqueCategory.lower()
+        categoryInfo['failures'] = failureCausesCollection.collection.count_documents({'lastOccurred': {'$gte': dailyFailures['midnight']}, 'categories': {'$in': [uniqueCategory]}})
+        failureCounts.append(categoryInfo)
 
-# pprint.pprint(failureCounts)
+    uncategorizedFailureInfo = {}
+    uncategorizedFailureInfo['category'] = u'uncategorized'
+    uncategorizedFailureInfo['failures'] = len(dailyFailures['uncategorizedFailures'])
+    failureCounts.append(uncategorizedFailureInfo)
+
+    failure_causes_info = {}
+    failure_causes_info['category'] = u'all'
+    failure_causes_info['failures'] = dailyFailures['daily_failure_causes_count']
+    failureCounts.append(failure_causes_info)
+    print(failureCounts)
+    return failureCounts
 
 class CustomCollector(object):
     def collect(self):
-        c = CounterMetricFamily('jenkins_bfa_failures_total', 'Total failures since midnight', labels=['failure_category'])
+        c = CounterMetricFamily('jenkins_bfa_failures', 'Total failures since midnight', labels=['failure_category'])
+        failureCounts = get_failure_counts(self)
         for failureCount in failureCounts:
             metric_name = failureCount['category']
             metric_value = failureCount['failures']
             c.add_metric([metric_name], metric_value)
-        c.add_metric(['all'], dailyFailureCauses.count())
         yield c
 
 REGISTRY.register(CustomCollector())
@@ -58,3 +80,4 @@ if __name__ == '__main__':
     start_http_server(8000)
     while True:
         CustomCollector.collect
+        time.sleep(30.0 - time.time() % 30.0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+prometheus_client
+pymongo
+


### PR DESCRIPTION
- switch to pulling from today since midnight (this seems more reliable and fits with the endpoint idea better)
- expose metrics via Prometheus client library 

**Sample output:**

```plain
# HELP jenkins_bfa_failures_total Total failures since midnight
# TYPE jenkins_bfa_failures_total counter
jenkins_bfa_failures_total{failure_category="apt"} 1.0
jenkins_bfa_failures_total{failure_category="network"} 1.0
jenkins_bfa_failures_total{failure_category="debian"} 1.0
jenkins_bfa_failures_total{failure_category="ubuntu"} 1.0
jenkins_bfa_failures_total{failure_category="test-suspected"} 4.0
jenkins_bfa_failures_total{failure_category="infrastructure-confirmed"} 4.0
jenkins_bfa_failures_total{failure_category="product-suspected"} 10.0
jenkins_bfa_failures_total{failure_category="infrastructure-suspected"} 9.0
jenkins_bfa_failures_total{failure_category="product-confirmed"} 2.0
jenkins_bfa_failures_total{failure_category="transient"} 2.0
jenkins_bfa_failures_total{failure_category="uncategorized"} 31.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="2",minor="7",patchlevel="16",version="2.7.16"} 1.0
```